### PR TITLE
Replacing yarnoj with rjcdr

### DIFF
--- a/data/dual-license-responses.json
+++ b/data/dual-license-responses.json
@@ -9047,7 +9047,7 @@
         }
       },
       {
-        "gitHubLogin": "yarnoj"
+        "gitHubLogin": "rjcdr"
       },
       {
         "gitHubLogin": "yoavf",


### PR DESCRIPTION
There is no longer a [yarnoj GitHub account](https://github.com/yarnoj). Looking at the contribution from that user in the [merged PRs data](https://github.com/WordPress/gutenberg-license/blob/2e2a1524ebb917c4cf303d24494d459fe31f72d1/data/2021-04-16_merged-or-open-prs.json), shows that the Gutenberg PR yarnoj authored (#13574) is now authored by GitHub user [rjcdr](https://github.com/rjcdr) (I confirmed this by re-using the same GitHub API query that we originally used to fetch the merged PR data--it also now shows rjcdr instead of yarnoj). The name associated with rjcdr matches up with the name associated with the [yarnoj account that already claimed ownership of some unassociated commits](https://github.com/WordPress/gutenberg-license/blob/2e2a1524ebb917c4cf303d24494d459fe31f72d1/data/dual-license-responses.json#L424-L434) (presumably before the account was renamed to rjcdr).

For that reason, we should now seek consent from the rjcdr account instead of the (no longer existing under this name) yarnoj account. We were not requesting consent from rjcdr before now, so I think just replacing yarnoj with rjcdr makes sense. Let me know if any of that doesn't make sense or you think I might be approaching this the wrong way.