### PR TITLE
Require any entry that does not require consent to include notes

### DIFF
--- a/scripts/summarize-dual-license-responses.js
+++ b/scripts/summarize-dual-license-responses.js
@@ -19,6 +19,12 @@ const consentResponses = json.gitHubUserContributors.responses.reduce((acc, curr
             // We don't need a response from accounts that we do not need consent from
             if (current.consentNeeded === false) {
                 node = acc.consentNotNeeded
+                if (current.notes === undefined) {
+                    const message = 'All entries where consent is not needed should have a \'notes\' property providing an explanation,'
+                        + ` but ${current.gitHubLogin} has no \'notes\'. Aborting...`
+                    console.log('\x1b[30m\x1b[41m' + message + '\x1b[0m\n');
+                    process.exit();
+                }
             } else {
               node = acc.noResponse
             }

--- a/scripts/summarize-dual-license-responses.js
+++ b/scripts/summarize-dual-license-responses.js
@@ -6,6 +6,15 @@ const json = JSON.parse(fileContents)
 
 // **********************************************************************************************
 
+json.claimedEmails.responses.forEach( response => {
+    if (response.consentNeeded === false && response.notes === undefined) {
+        const message = 'All entries where a response is not needed should have a \'notes\' property providing an explanation,'
+            + ` but ${response.unassociatedCommitterEmail} has no \'notes\'. Aborting...`
+        console.log('\x1b[30m\x1b[41m' + message + '\x1b[0m\n');
+        process.exit();
+    }
+});
+
 const consentResponses = json.gitHubUserContributors.responses.reduce((acc, current) => {
     let node;
     switch (current.consent) {


### PR DESCRIPTION
Make sure there is some explanation for why we're saying we don't need a person's consent by making the script fail if there is not a "notes" field. I've been doing this until now ([for example](https://github.com/WordPress/gutenberg-license/blob/trunk/data/dual-license-responses.json#L2013-L2017)), but I think it would be good to enforce this requirement.

Editing one of the entries in `data/dual-licenseresponses.json` to include a `"consentNeeded": false`, but _not_ including a `"notes"` property should now cause `scripts/update-dual-license-responses.js` to fail with an error message.